### PR TITLE
Multiple inclusion bugfix: only process rows with source

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = function (mains, opts) {
     if (!opts) opts = {};
     if (opts.cache === undefined) opts.cache = cache;
     opts.includeSource = true;
-    
+
     mains.forEach(function (file) {
         pending ++;
         var p = 2, src, rows;
@@ -39,7 +39,9 @@ module.exports = function (mains, opts) {
             };
             
             walk(rows);
-            if (--pending === 0) output.queue(null);
+            if (--pending === 0) {
+                output.queue(null);
+            }
         }
         
         fs.readFile(file, 'utf8', function (err, s) {
@@ -63,7 +65,7 @@ module.exports = function (mains, opts) {
     
     function walk (rows) {
         rows.forEach(function (row) {
-            if (files[row.filename]) return;
+            if (!row.source || files[row.filename]) return;
             var r = files[row.filename] = {
                 id: row.filename,
                 source: row.source,


### PR DESCRIPTION
Required returns content only once, but since it's async it's not guaranteed that first request will get source, so we could only process rows with source.

Explanation by example:
1. require('some-module') in bunch of files
2. resulted file node:

``` json
{ id: 23,
  source: '(function(process,global,__filename,__dirname){undefined\n})(require("__browserify_process"),window,"/node_modules/compound/lib/client/util.js","/node_modules/compound/lib/client")',
  deps: { child_process: 28, __browserify_process: 1 },
  entry: false }
```

note "undefined\n" as source.

it happens because of sync forEach processing of all rows, which is fine, but it rely's on order of files, and first row with '/node_modules/compound/lib/client/util.js' may have no source, because required() call only returns source once per id, all other times source=undefined.

---

this is minimal changeset i've found to fix problem, probably you may like to come up with another way to fix it.
