### PR TITLE
Catch and handle parsing errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,13 @@ module.exports = function (mains, opts) {
     }
     
     function parseDeps (file, src) {
-        var deps = detective(src);
+        var deps;
+        try {
+            deps = detective(src);
+        } catch (ex) {
+            var message = ex && ex.message ? ex.message : ex;
+            return output.emit('error', new Error('Parsing file ' + file + ': ' + message));
+        }
         var p = deps.length;
         var current = { id: file, filename: file, paths: [] };
         var resolved = {};


### PR DESCRIPTION
Catch and handle exceptions thrown by detective/esprima. (The exception was uncaught, crashing the application.)
Add filename in error message to help fixing javascript errors.
