### PR TITLE
don't abort on error

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,10 @@ module.exports = function (mains, opts) {
         };
         
         resolve(id, parent, function (err, file) {
+            if (err || !file) {
+              pending -= 2;
+              if (pending === 0) setTimeout(output.queue.bind(output, null));
+            }
             if (err) return output.emit('error', err);
             if (!file) return output.emit('error', new Error([
                 'module not found: "' + id + '" from file ',

--- a/test/end.js
+++ b/test/end.js
@@ -1,0 +1,26 @@
+var parser = require('../');
+var test = require('tap').test;
+var fs = require('fs');
+
+var file = __dirname + '/files/error.js';
+var source = fs.readFileSync(file).toString();
+
+test('error', function (t) {
+    t.plan(1);
+    var p = parser(file)
+    p.on('error', function () {});
+
+    var rows = [];
+    
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows, [
+            {
+                id: file,
+                source: source,
+                deps: { './error2.js': __dirname + '/files/error2.js' },
+                entry: true
+            }
+        ]);
+    });
+});

--- a/test/files/error.js
+++ b/test/files/error.js
@@ -1,0 +1,1 @@
+require('./error2.js');

--- a/test/files/error2.js
+++ b/test/files/error2.js
@@ -1,0 +1,1 @@
+require('foobarbazbeepboop');


### PR DESCRIPTION
This makes the module continue working when an emitted error is catched.

Otherwise, we could add an option like:

``` js
opts.exclude = 'node_modules'
```

Which will skip all files whose paths match `node_modules`
