### PR TITLE
AMD mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,44 +1,45 @@
 {
-    "name": "module-deps",
-    "version": "0.7.1",
-    "description": "walk the dependency graph to generate json output that can be fed into browser-pack",
-    "main": "index.js",
-    "bin": {
-        "module-deps": "cmd.js"
-    },
-    "dependencies": {
-        "through": "~2.3.2",
-        "JSONStream": "~0.4.3",
-        "browser-resolve": "~0.1.0",
-        "resolve": "~0.3.0",
-        "detective": "~2.1.1",
-        "concat-stream": "~0.1.1"
-    },
-    "devDependencies": {
-        "tap": "~0.4.0",
-        "browser-pack": "~0.0.0"
-    },
-    "scripts": {
-        "test": "tap test/*.js"
-    },
-    "repository": {
-        "type": "git",
-        "url": "git://github.com/substack/module-deps.git"
-    },
-    "homepage": "https://github.com/substack/module-deps",
-    "keywords": [
-        "dependency",
-        "graph",
-        "browser",
-        "require",
-        "module",
-        "exports",
-        "json"
-    ],
-    "author": {
-        "name": "James Halliday",
-        "email": "mail@substack.net",
-        "url": "http://substack.net"
-    },
-    "license": "MIT"
+  "name": "module-deps",
+  "version": "0.7.1",
+  "description": "walk the dependency graph to generate json output that can be fed into browser-pack",
+  "main": "index.js",
+  "bin": {
+    "module-deps": "cmd.js"
+  },
+  "dependencies": {
+    "through": "~2.3.2",
+    "JSONStream": "~0.4.3",
+    "browser-resolve": "~0.1.0",
+    "resolve": "~0.3.0",
+    "detective": "~2.1.1",
+    "concat-stream": "~0.1.1",
+    "module-investigator": "~0.1.2"
+  },
+  "devDependencies": {
+    "tap": "~0.4.0",
+    "browser-pack": "~0.0.0"
+  },
+  "scripts": {
+    "test": "tap test/*.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/module-deps.git"
+  },
+  "homepage": "https://github.com/substack/module-deps",
+  "keywords": [
+    "dependency",
+    "graph",
+    "browser",
+    "require",
+    "module",
+    "exports",
+    "json"
+  ],
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "license": "MIT"
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -78,6 +78,8 @@ and falsey for all the ids to skip.
 * opts.packageFilter - transform the parsed package.json contents before using
 the values. `opts.packageFilter(pkg)` should return the new `pkg` object to use.
 
+* opts.amdMode - check for AMD-style dependencies as well. Report dependency format for each file.
+
 # transforms
 
 module-deps can be configured to run source transformations on files before

--- a/test/deps-amd-mode.js
+++ b/test/deps-amd-mode.js
@@ -1,0 +1,55 @@
+var parser = require('../');
+var test = require('tap').test;
+var fs = require('fs');
+
+var files = {
+    main: __dirname + '/files/main-amd.js',
+    foo: __dirname + '/files/foo.js',
+    bar: __dirname + '/files/bar.js',
+    baz: __dirname + '/files/baz.js'
+};
+
+var sources = Object.keys(files).reduce(function (acc, file) {
+    acc[file] = fs.readFileSync(files[file], 'utf8');
+    return acc;
+}, {});
+
+test('deps', function (t) {
+    t.plan(1);
+    var p = parser(files.main, {amdMode: true});
+    var rows = [];
+    
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows, [
+            {
+                id: files.main,
+                source: sources.main,
+                entry: true,
+                format: 'amd',
+                deps: { './baz': files.baz }
+            },
+            {
+                id: files.baz,
+                source: sources.baz,
+                format: 'amd',
+                deps: { 
+                  './bar': files.bar,
+                  './foo': files.foo
+                }
+            },
+            {
+                id: files.bar,
+                source: sources.bar,
+                format: 'commonJS',
+                deps: {}
+            },
+            {
+                id: files.foo,
+                source: sources.foo,
+                format: 'commonJS',
+                deps: { './bar': files.bar }
+            }
+        ]);
+    });
+});

--- a/test/files/baz.js
+++ b/test/files/baz.js
@@ -1,0 +1,7 @@
+define(["./bar"], function(bar) {
+    require(["./foo"], function() {
+        return function (n) {
+            return bar(n) * foo(n);
+        };
+    });
+});

--- a/test/files/main-amd.js
+++ b/test/files/main-amd.js
@@ -1,0 +1,3 @@
+define(["./baz"], function(foo) {
+    console.log('main: ' + foo(5));
+});


### PR DESCRIPTION
AMD mode uses https://github.com/jpka/module-investigator instead of node-detective to check for AMD style dependencies, return those if it finds them, else returns the regular CommonJS-style ones. Also it brands each file with a property format that specifies which type of dependency is returning.

I know this is nowhere near a feature intended for this module, but I am submitting it anyway in hopes of avoiding an unnecessary(?) fork. If the fork is indeed necessary, let me know.
