### PR TITLE
Do not apply top-level transforms to builtins

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ module.exports = function (mains, opts) {
     function applyTransforms (file, trx, src, pkg) {
         var isTopLevel = mains.some(function (main) {
             var m = path.relative(path.dirname(main), file);
-            return m.split('/').indexOf('node_modules') < 0;
+            return m.split('/').indexOf('node_modules') < 0 && m.split('/').indexOf('browser-builtins') < 0;
         });
         var transf = (isTopLevel ? transforms : []).concat(trx);
         if (transf.length === 0) return done();


### PR DESCRIPTION
Currently, transforms are being attempted on builtins.  However, resolution of that transform usually fails, because it can't be resolved from the builtin path.

For example, the builtin path is:
/Projects/node/browser-builtins/builtin/querystring.js

But the transform is located in:
/Projects/js/foo/node_modules/deamdify/index.js

I'm not sure I like the approach of hardcoding `browser-builtins` as a path.  All the other methods I tried quickly became overcomplicated.

Good enough?  Other suggestions?
