### PR TITLE
Native CoffeeScript support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var spawn = require('child_process').spawn;
+var coffeescript = require('coffee-script');
 
 var browserResolve = require('browser-resolve');
 var nodeResolve = require('resolve');
@@ -95,6 +96,19 @@ module.exports = function (mains, opts) {
             if (cache && cache[file]) {
                 parseDeps(file, cache[file], pkg);
             }
+            else if (path.extname(file) == '.coffee') {
+                try {
+                    var src = coffeescript.compile(fs.readFileSync(file, 'utf8', {filename: file}));
+                    applyTransforms(file, trx, src, pkg);
+                }
+                catch (ex) {
+                    var message = ex && ex.message ? ex.message : ex;
+                    return output.emit('error', new Error(
+                        'Compiling file ' + file + ': ' + message
+                    ));
+                }
+            }
+
             else fs.readFile(file, 'utf8', function (err, src) {
                 if (err) return output.emit('error', err);
                 applyTransforms(file, trx, src, pkg);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "browser-resolve": "~1.1.0",
         "resolve": "~0.4.0",
         "detective": "~2.1.2",
-        "concat-stream": "~1.0.0"
+        "concat-stream": "~1.0.0",
+        "coffee-script": "*"
     },
     "devDependencies": {
         "tap": "~0.4.0",


### PR DESCRIPTION
I was trying to package a CoffeeScript library for browser support using your awesome browserify CLI.

Due to nested module dependencies, I wasn't able to use coffeeify because I do not know what modules are required by each CoffeeScript module and given the work you've already done, it was more easy to add natively (when module-deps encounters a .coffee file, it just compiles it and hands it off).

It you accept this pull request, there is corresponding one on node-resolve (https://github.com/substack/node-resolve/pull/23) to also accept.

Cheers!
