### PR TITLE
Support using the `"transform"` property in pkg.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -217,7 +217,7 @@ module.exports = function (mains, opts) {
     function makeTransform (file, tr, cb) {
         if (typeof tr === 'function') return cb(null, tr(file));
         
-        var params = { basedir: path.dirname(file) };
+        var params = { basedir: path.dirname(file), packageFilter: packageFilter };
         nodeResolve(tr, params, function nr (err, res, again) {
             if (err && again) return cb(err);
             
@@ -236,5 +236,11 @@ module.exports = function (mains, opts) {
             
             cb(null, require(res)(file));
         });
+        function packageFilter(info) {
+            if (typeof info.transform === 'string') {
+                info.main = info.transform
+            }
+            return info
+        }
     }
 };


### PR DESCRIPTION
This allows modules to expose a browserify transform that is not their primary export.  This would make it easy for the browserify transform and the simple module transformation to co-exist in the same module.

e.g.

index.js

``` js
module.exports = function (text) {
  return text.replace(/AAA/g, 'aaa')
}
```

transform.js

``` js
var Transform = require('stream').Transform
var bufferedTransform = require('./index.js')

module.exports = function (filename) {
  var res = new Transform()
  var buf = ''
  res._transform = function (chunk, encoding, callback) {
    buf += chunk.toString()
    callback()
  }
  res._flush = function (callback) {
    this.push(bufferedTransform(buf))
    callback()
  }
  return res
}
```

package.json

``` js
{
  "name": "my-transform",
  "version": "0.0.0",
  "main": "index.js",
  "transform": "transform.js"
}
```

The point is to ensure that the interface exposed by the transforming module is the simplest interface possible, but everything can be adapted to support browserify without adding an extra module.
