### PR TITLE
When package does not specify its own tranform, use transform from opts

### DIFF
--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ module.exports = function (mains, opts) {
             var m = path.relative(path.dirname(main), file);
             return m.split('/').indexOf('node_modules') < 0;
         });
-        var transf = (isTopLevel ? transforms : []).concat(trx);
+        var transf = ((isTopLevel || !trx.length) ? transforms : []).concat(trx);
         if (transf.length === 0) return done();
         
         (function ap (trs) {


### PR DESCRIPTION
Ran into this behavior in https://github.com/substack/node-browserify/issues/501.  Right now, non-toplevel modules cannot be transformed unless they specify transforms in their own package.json.  

IMO, I would expect transforms provided by client code (e.g. the `opts.transform` provided by browserify) to be the default fallback for non-configured modules, rather than falling back to no transforms at all.  Does this make sense?
