### PR TITLE
Updating concat-stream to restore node 0.8 and 0.6 compatibility.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "browser-resolve": "~1.2.2",
     "resolve": "~0.6.0",
     "detective": "~2.1.2",
-    "concat-stream": "~1.3.1",
+    "concat-stream": "~1.4.1",
     "minimist": "~0.0.5",
     "parents": "0.0.2"
   },
@@ -43,7 +43,7 @@
     "url": "http://substack.net"
   },
   "engines": {
-    "node": ">= 0.10"
+    "node": ">= 0.6"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Per https://github.com/substack/coverify/issues/4#issuecomment-31387207
