### PR TITLE
fix for packageTransform option bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,7 +131,7 @@ module.exports = function (mains, opts) {
                     if (!p) p = {};
                     if (!p.__dirname) p.__dirname = path.dirname(file);
                     pkgCache[file] = p;
-                    f(err, file, p);
+                    f(err, file, opts.packageFilter ? opts.packageFilter(p) : p);
                 });
                 return;
             }


### PR DESCRIPTION
Hi James,

Been banging my head against the wall trying to track down an issue related to the packageFilter option. Looks like there is a bug in module deps to whereas at times it will not apply the package filter to parsed package jsons. Specifically, in the "walk" function, if lookupPkg needs to be called because `pkg.__dirname` is missing (line 129), the packageFilter is not applied to the parsed package json. However, it IS applied in the case that `pkg.__dirname` is present, as the pkg comes back from resolver already transformed. The PR fixes the issue so that the package filter is applied consistently across both cases.
