### PR TITLE
pass dir as second argument to packageFilter

### DIFF
--- a/index.js
+++ b/index.js
@@ -137,7 +137,7 @@ module.exports = function (mains, opts) {
                     if (!p) p = {};
                     if (!p.__dirname) p.__dirname = path.dirname(file);
                     pkgCache[file] = p;
-                    f(err, file, opts.packageFilter ? opts.packageFilter(p) : p);
+                    f(err, file, opts.packageFilter ? opts.packageFilter(p, p.__dirname) : p);
                 });
                 return;
             }


### PR DESCRIPTION
Adds the extra argument of the path name to the packageFilter added in https://github.com/substack/module-deps/commit/e97e71286fe56720a27741b88e021083174764e8
