### PR TITLE
Don't flag file as not resolvable too early

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,7 +398,6 @@ Deps.prototype.lookupPackage = function (file, cb) {
             else if (pkg) cb(null, pkg)
             else {
                 self.pkgCache[pkgfile] = false;
-                self.pkgCache[file] = false;
                 next();
             }
         }


### PR DESCRIPTION
After hours of tracing, I found my bug of the day!

When looking for a package, say `./lib/package.json`, the file is sometimes marked as unresolvable, even if `./package.json` exists. Whether this works or not depends on the order of `fs.readFile` yields. The `next()` implementation already flags the file as unresolvable correctly when there are no directories left to check.

Also, [this line](https://github.com/substack/module-deps/blob/master/index.js#L142) causes module-deps to return an empty object with just the `__dirname` in it, which makes browserify work in this case. However, I have a `browserify.transform` field in the `package.json` which is then not present, hence the transform is never invoked.

Maybe you have some idea on how to improve error handling in this case.
