### PR TITLE
Bumping parents version to ~1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "duplexer2": "0.0.2",
     "inherits": "~2.0.1",
     "minimist": "~0.0.9",
-    "parents": "0.0.2",
+    "parents": "~1.0.0",
     "resolve": "~0.6.3",
     "stream-combiner": "~0.1.0",
     "through2": "~0.4.1",


### PR DESCRIPTION
Bump version of parents to ~1.0.0. This fixes an issue on Windows where the correct package.json isn’t found and can break things like substack/node-browserify transforms, e.g. partialify, when subdirectories have a package.json.
