### PR TITLE
Fixing tests that were failing on Windows

### DIFF
--- a/test/deps.js
+++ b/test/deps.js
@@ -1,11 +1,12 @@
 var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
+var path = require('path');
 
 var files = {
-    main: __dirname + '/files/main.js',
-    foo: __dirname + '/files/foo.js',
-    bar: __dirname + '/files/bar.js'
+    main: path.join(__dirname, '/files/main.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
 };
 
 var sources = Object.keys(files).reduce(function (acc, file) {

--- a/test/noparse.js
+++ b/test/noparse.js
@@ -1,11 +1,12 @@
 var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
+var path = require('path');
 
 var files = {
-    main: __dirname + '/files/main.js',
-    foo: __dirname + '/files/foo.js',
-    bar: __dirname + '/files/bar.js'
+    main: path.join(__dirname, '/files/main.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
 };
 
 var sources = Object.keys(files).reduce(function (acc, file) {

--- a/test/unicode.js
+++ b/test/unicode.js
@@ -1,11 +1,12 @@
 var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
+var path = require('path');
 
 var files = {
-    main: __dirname + '/files/unicode/main.js',
-    foo: __dirname + '/files/unicode/foo.js',
-    bar: __dirname + '/files/unicode/bar.js'
+    main: path.join(__dirname, '/files/unicode/main.js'),
+    foo: path.join(__dirname, '/files/unicode/foo.js'),
+    bar: path.join(__dirname, '/files/unicode/bar.js')
 };
 
 var sources = Object.keys(files).reduce(function (acc, file) {


### PR DESCRIPTION
The expected paths had not been normalized for Windows. I switched the expectations to build the path with `path.join()` instead of string concatenation.
