### PR TITLE
Correct a `this` to `self`

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ Deps.prototype._transform = function (row, enc, next) {
     if (row.entry !== false) self.entries.push(row.file);
     
     self.lookupPackage(row.file, function (err, pkg) {
-        if (err && this.options.ignoreMissing) {
+        if (err && self.options.ignoreMissing) {
             self.emit('missing', row.file, self.top);
             self.pending --;
             return next();


### PR DESCRIPTION
This is a small fix to use `self` instead of `this`. this references the callback function and not the main method.
