### PR TITLE
Fix tests failing on Windows

### DIFF
--- a/test/bundle.js
+++ b/test/bundle.js
@@ -2,11 +2,12 @@ var parser = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('bundle', function (t) {
     t.plan(1);
     var p = parser();
-    p.end(__dirname + '/files/main.js');
+    p.end(path.join(__dirname, '/files/main.js'));
     p.on('error', t.fail.bind(t));
     var pack = packer();
     

--- a/test/cycle.js
+++ b/test/cycle.js
@@ -3,11 +3,12 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var concat = require('concat-stream');
+var path = require('path');
 
 test('cycle', function (t) {
     t.plan(1);
     var p = mdeps();
-    p.end(__dirname + '/cycle/main.js');
+    p.end(path.join(__dirname, '/cycle/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack).pipe(concat(function (src) {

--- a/test/dotdot.js
+++ b/test/dotdot.js
@@ -1,16 +1,17 @@
 var mdeps = require('../');
 var test = require('tape');
 var through = require('through2');
+var path = require('path');
 
-test(function (t) {
+test('dotdot', function (t) {
     var expected = [
-        __dirname + '/dotdot/index.js',
-        __dirname + '/dotdot/abc/index.js'
+        path.join(__dirname, '/dotdot/index.js'),
+        path.join(__dirname, '/dotdot/abc/index.js')
     ];
     t.plan(expected.length);
     
     var d = mdeps();
-    d.end(__dirname + '/dotdot/abc/index.js');
+    d.end(path.join(__dirname, '/dotdot/abc/index.js'));
     
     d.pipe(through.obj(function (row, enc, next) {
         t.deepEqual(row.file, expected.shift());

--- a/test/expose.js
+++ b/test/expose.js
@@ -1,10 +1,11 @@
 var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
+var path = require('path');
 
 var files = {
-    foo: __dirname + '/files/foo.js',
-    bar: __dirname + '/files/bar.js'
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
 };
 
 var sources = Object.keys(files).reduce(function (acc, file) {

--- a/test/noparse_row.js
+++ b/test/noparse_row.js
@@ -2,11 +2,12 @@ var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
 var concat = require('concat-stream');
+var path = require('path');
 
 var files = {
-    main: __dirname + '/files/main.js',
-    foo: __dirname + '/files/foo.js',
-    bar: __dirname + '/files/bar.js'
+    main: path.join(__dirname, '/files/main.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
 };
 
 var sources = Object.keys(files).reduce(function (acc, file) {

--- a/test/pkg.js
+++ b/test/pkg.js
@@ -1,8 +1,9 @@
 var mdeps = require('../');
 var test = require('tape');
+var path = require('path');
 
 var pkg = require('./pkg/package.json');
-pkg.__dirname = __dirname + '/pkg';
+pkg.__dirname = path.join(__dirname, '/pkg');
 
 test('pkg', function (t) {
     t.plan(1);
@@ -11,6 +12,6 @@ test('pkg', function (t) {
     d.on('package', function (pkg_) {
         t.deepEqual(pkg_, pkg);
     });
-    d.end(__dirname + '/pkg/main.js');
+    d.end(path.join(__dirname, '/pkg/main.js'));
     d.resume();
 });

--- a/test/pkg_filter.js
+++ b/test/pkg_filter.js
@@ -3,6 +3,7 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var concat = require('concat-stream');
+var path = require('path');
 
 test('pkg filter', function (t) {
     t.plan(3);
@@ -14,7 +15,7 @@ test('pkg filter', function (t) {
             return pkg;
         }
     });
-    p.end(__dirname + '/files/pkg_filter/test.js');
+    p.end(path.join(__dirname, '/files/pkg_filter/test.js'));
     
     var pack = packer();
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/source.js
+++ b/test/source.js
@@ -1,12 +1,13 @@
 var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
+var path = require('path');
 
 var files = {
-    main: __dirname + '/files/main.js',
-    foo: __dirname + '/files/foo.js',
-    bar: __dirname + '/files/bar.js',
-    extra: __dirname + '/files/extra.js'
+    main: path.join(__dirname, '/files/main.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js'),
+    extra: path.join(__dirname, '/files/extra.js')
 };
 var sources = {
     foo: fs.readFileSync(files.foo, 'utf8'),

--- a/test/tr_2dep_module.js
+++ b/test/tr_2dep_module.js
@@ -2,6 +2,7 @@ var mdeps = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(3);
@@ -9,7 +10,7 @@ test('transform', function (t) {
         transform: [ 'insert-aaa', 'insert-bbb' ],
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_2dep_module/main.js');
+    p.end(path.join(__dirname, '/files/tr_2dep_module/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/tr_err.js
+++ b/test/tr_err.js
@@ -3,6 +3,7 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var through = require('through');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(1);
@@ -14,7 +15,7 @@ test('transform', function (t) {
         }
     });
     p.on('error', function (err) {
-        t.ok(/tr_sh\/main\.js/.test(err));
+        t.ok(/tr_sh[\\\/]main\.js/.test(err));
     });
-    p.end(__dirname + '/files/tr_sh/main.js');
+    p.end(path.join(__dirname, '/files/tr_sh/main.js'));
 });

--- a/test/tr_fn.js
+++ b/test/tr_fn.js
@@ -3,6 +3,7 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var through = require('through');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(3);
@@ -17,7 +18,7 @@ test('transform', function (t) {
         },
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_sh/main.js');
+    p.end(path.join(__dirname, '/files/tr_sh/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/tr_global.js
+++ b/test/tr_global.js
@@ -3,6 +3,7 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var concat = require('concat-stream');
+var path = require('path');
 
 test('global transforms', function (t) {
     t.plan(1);
@@ -10,12 +11,12 @@ test('global transforms', function (t) {
     var p = mdeps({
         transform: [ 'tr-c', 'tr-d' ],
         globalTransform: [
-            __dirname + '/files/tr_global/node_modules/tr-e',
-            __dirname + '/files/tr_global/node_modules/tr-f'
+            path.join(__dirname, '/files/tr_global/node_modules/tr-e'),
+            path.join(__dirname, '/files/tr_global/node_modules/tr-f')
         ],
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_global/main.js');
+    p.end(path.join(__dirname, '/files/tr_global/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack).pipe(concat(function (src) {

--- a/test/tr_module.js
+++ b/test/tr_module.js
@@ -2,6 +2,7 @@ var mdeps = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(4);
@@ -9,7 +10,7 @@ test('transform', function (t) {
         transform: [ 'insert-aaa', 'insert-bbb' ],
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_module/main.js');
+    p.end(path.join(__dirname, '/files/tr_module/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/tr_opts.js
+++ b/test/tr_opts.js
@@ -3,13 +3,14 @@ var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
 var concat = require('concat-stream');
+var path = require('path');
 
 test('transform options', function (t) {
     t.plan(1);
     var p = mdeps({
         transformKey: [ 'mdtr' ]
     });
-    p.end(__dirname + '/tr_opts/main.js');
+    p.end(path.join(__dirname, '/tr_opts/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack).pipe(concat(function (src) {

--- a/test/tr_rel.js
+++ b/test/tr_rel.js
@@ -2,13 +2,14 @@ var mdeps = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(1);
     var p = mdeps({
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_rel/subdir/main.js');
+    p.end(path.join(__dirname, '/files/tr_rel/subdir/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/tr_sh.js
+++ b/test/tr_sh.js
@@ -2,6 +2,7 @@ var mdeps = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(3);
@@ -9,7 +10,7 @@ test('transform', function (t) {
         transform: [ './tr_a.js', './tr_b.js' ],
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_sh/main.js');
+    p.end(path.join(__dirname, '/files/tr_sh/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);

--- a/test/tr_whole_package.js
+++ b/test/tr_whole_package.js
@@ -2,13 +2,14 @@ var mdeps = require('../');
 var test = require('tape');
 var JSONStream = require('JSONStream');
 var packer = require('browser-pack');
+var path = require('path');
 
 test('transform', function (t) {
     t.plan(1);
     var p = mdeps({
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end(__dirname + '/files/tr_whole_package/main.js');
+    p.end(path.join(__dirname, '/files/tr_whole_package/main.js'));
     var pack = packer();
     
     p.pipe(JSONStream.stringify()).pipe(pack);


### PR DESCRIPTION
This is a friendly request to always use `path.join` instead of string concatenation when dealing with paths, in order to support the lesser platform :)
