### PR TITLE
Adds dubious fix for a possible error with loadTransform

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,7 +237,9 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     }
     
     function loadTransform (id, trOpts, cb) {
-        var params = { basedir: path.dirname(file) };
+        var params = {
+            basedir: trOpts.basedir || path.dirname(file)
+        };
         nodeResolve(id, params, function nr (err, res, again) {
             if (err && again) return cb(err);
             


### PR DESCRIPTION
Hello @substack et al,

I have a issue that I don't totally understand and a fix that I don't totally understand either :stuck_out_tongue:. Perhaps by explaining the issue and showing the fix here someone can tell me what I've done wrong (or maybe what I've done right).

Here's the issue: I have an express app (let's call it B), that uses Browserify and the [strictify](https://github.com/jsdf/strictify) plugin in a gulp task to bundle front-end JavaScript. Usually this works just fine. Then, for reasons I'd rather not get into, it made sense for B to be exported as a module into another express app (let's call it A), and used as middleware. (To make it's assets available, B has a postinstall script to run gulp.)

B has dependencies that are mostly non-overlapping with A's dependencies, except for underscore. As a result, running `npm install` on A puts underscore in A/node_modules and not in A/node_modules/B/node_modules.

In this arrangement, running the B's gulp task results in this error:

```
events.js:7
    throw er; // Unhandled 'error' event
        ^
Error: Cannot find module 'strictify' from '/home/zachrose/A/node_modules/underscore'
    at /home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:50:17
    at process (/home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:119:43)
    at /home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:128:21
    at load (/home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:60:43)
    at /home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:66:22
    at /home/zachrose/A/node_modules/B/node_modules/browserify/node_modules/resolve/lib/async.js:21:47
    at Object.oncomplete (fs.js:107:15)
```

After some trial and error, I discovered this change to module_deps, in addition to that adding `{basedir: __dirname}` as an option to my transform, like so:

```
    browserify({ /* yadda-yadda */}).transform('strictify', {basedir: __dirname})
```

...prevents the error and seems to make everything work ok. (This change doesn't fail the tests, but of course that doesn't mean it's the correct thing to do.)

So here are my questions:
- What is the dirname option to b.transform supposed to do? Is it supposed to give a place to start looking for the transforming module (e.g. strictify?)
- If not, is there another way I should be resolving my problem?

Thanks!
