### PR TITLE
Add `opts.expose` object to populate resolved pathnames for exposed modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,10 @@ function Deps (opts) {
     this.resolver = opts.resolve || browserResolve;
     this.options = copy(opts || {});
     if (!this.options.modules) this.options.modules = {};
+
+    // If the caller passes options.expose, store resolved pathnames for exposed
+    // modules in it. If not, set it anyway so it's defined later.
+    if (!this.options.expose) this.options.expose = {};
     this.pending = 0;
     
     var topfile = path.join(this.basedir, '__fake.js');

--- a/index.js
+++ b/index.js
@@ -290,7 +290,11 @@ Deps.prototype.walk = function (id, parent, cb) {
     
     self.resolve(id, parent, function (err, file, pkg) {
         if (rec.expose) {
-            self.options.modules[rec.expose] = file;
+            // Set options.expose to make the resolved pathname available to the
+            // caller. They may or may not have requested it, but it's harmless
+            // to set this if they didn't.
+            self.options.expose[rec.expose] =
+                self.options.modules[rec.expose] = file;
         }
         if (pkg) self.emit('package', pkg);
         

--- a/test/row_expose.js
+++ b/test/row_expose.js
@@ -1,0 +1,24 @@
+var parser = require('../');
+var test = require('tape');
+var stream = require('readable-stream');
+var path = require('path');
+
+// Test that p.options.expose is defined and that the row is properly exposed
+// (resolved to the absolute pathname corresponding to the `file` value passed
+// in the row, and set in opts.expose).
+test('row is exposed', function (t) {
+    t.plan(1);
+    var common_path = path.join(__dirname, '/files/main');
+    var opts = { expose: {} };
+    var p = parser(opts);
+    // Note pathname without extension.
+    p.end({ file: common_path, expose: "whatever" });
+    p.on('error', t.fail.bind(t));
+
+    p.pipe(new stream.PassThrough({ objectMode: true }));
+
+    p.on('end', function () {
+        // Note pathname with extension.
+        t.equal(opts.expose.whatever, common_path + '.js');
+    });
+});


### PR DESCRIPTION
This is to support related changes on browserify (substack/node-browserify/pull/1077).

What's the logic for what properties from `opts` become `this.something` vs remaining accessible as `this.options.something`?