### PR TITLE
Remove unused child_process spawn require

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 var fs = require('fs');
 var path = require('path');
-var spawn = require('child_process').spawn;
 
 var browserResolve = require('browser-resolve');
 var nodeResolve = require('resolve');


### PR DESCRIPTION
Removes an unneeded `require('child_process')` (added in 56147f9455366c2a0a1b27029e7d686bb3531c76 but no longer used). All tests continue to pass after this removal.