### PR TITLE
Enforce entries[] index as local filepath style

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ Deps.prototype._transform = function (row, enc, next) {
     }
     
     self.pending ++;
-    if (row.entry !== false) self.entries.push(row.file);
+    if (row.entry !== false) self.entries.push(path.resolve(row.basedir, row.file));
     
     self.lookupPackage(row.file, function (err, pkg) {
         if (err && self.options.ignoreMissing) {


### PR DESCRIPTION
On Windows, fix the example.
Not positive path.resolve() is the way to go, might just use two replace(/\\/g,'/') on lines 83 and 396.