### PR TITLE
Fix mysteriously disappearing "expose" and "entry"

### DIFF
--- a/test/cache.js
+++ b/test/cache.js
@@ -1,0 +1,50 @@
+var parser = require('../');
+var test = require('tape');
+var path = require('path');
+
+var files = {
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = {
+    foo: 'notreal foo',
+    bar: 'notreal bar'
+};
+
+var cache = {};
+cache[files.foo] = {
+    source: sources.foo,
+    deps: { './bar': files.bar }
+};
+cache[files.bar] = {
+    source: sources.bar,
+    deps: {}
+};
+
+test('uses cache', function (t) {
+    t.plan(1);
+    var p = parser({ cache: cache });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+    
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: 'foo',
+                file: files.foo,
+                source: sources.foo,
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                file: files.bar,
+                source: sources.bar,
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/cache_expose.js
+++ b/test/cache_expose.js
@@ -1,0 +1,54 @@
+var parser = require('../');
+var test = require('tape');
+var path = require('path');
+
+var files = {
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = {
+    foo: 'notreal foo',
+    bar: 'notreal bar'
+};
+
+var cache = {};
+cache[files.foo] = {
+    source: sources.foo,
+    deps: { './bar': files.bar }
+};
+cache[files.bar] = {
+    source: sources.bar,
+    deps: {}
+};
+
+test('cache preserves expose and entry', function (t) {
+    t.plan(1);
+    var p = parser({ cache: cache });
+    p.write({ id: files.bar, expose: 'bar2', entry: false });
+    p.end({ id: 'foo', file: files.foo, entry: true, expose: 'foo2' });
+    
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: 'foo',
+                expose: 'foo2',
+                entry: true,
+                file: files.foo,
+                source: sources.foo,
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                expose: 'bar2',
+                file: files.bar,
+                source: sources.bar,
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/cache_partial.js
+++ b/test/cache_partial.js
@@ -1,0 +1,47 @@
+var parser = require('../');
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+
+var files = {
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = {
+    foo: 'notreal foo',
+    bar: fs.readFileSync(files.bar, 'utf8')
+};
+
+var cache = {};
+cache[files.foo] = {
+    source: sources.foo,
+    deps: { './bar': files.bar }
+};
+
+test('uses cache and reads from disk', function (t) {
+    t.plan(1);
+    var p = parser({ cache: cache });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+    
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: 'foo',
+                file: files.foo,
+                source: sources.foo,
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                file: files.bar,
+                source: sources.bar,
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/cache_partial_expose.js
+++ b/test/cache_partial_expose.js
@@ -1,0 +1,104 @@
+var parser = require('../');
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+var copy = require('shallow-copy');
+
+var files = {
+    abc: path.join(__dirname, '/expose/lib/abc.js'),
+    xyz: path.join(__dirname, '/expose/lib/xyz.js'),
+    foo: path.join(__dirname, '/expose/foo.js'),
+    bar: path.join(__dirname, '/expose/bar.js'),
+    main: path.join(__dirname, '/expose/main.js')
+};
+
+var sources = Object.keys(files).reduce(function (acc, file) {
+    acc[file] = fs.readFileSync(files[file], 'utf8');
+    return acc;
+}, {});
+
+var cache = {};
+cache[files.abc] = {
+    source: sources.abc,
+    deps: {}
+};
+cache[files.xyz] = {
+    source: sources.xyz,
+    deps: {'../foo': files.foo}
+};
+cache[files.foo] = {
+    source: sources.foo,
+    deps: {'./lib/abc': files.abc}
+};
+cache[files.bar] = {
+    source: sources.bar,
+    deps: {xyz: files.xyz}
+};
+cache[files.main] = {
+    source: sources.main,
+    deps: {
+        abc: files.abc,
+        xyz: files.xyz,
+        './bar': files.bar
+    }
+};
+
+test('preserves expose and entry with partial cache', function(t) {
+    t.plan(1);
+
+    var partialCache = copy(cache);
+    delete partialCache[files.bar];
+
+    var p = parser({ cache: partialCache });
+    p.write({ id: 'abc', file: files.abc, expose: 'abc' });
+    p.write({ id: 'xyz', file: files.xyz, expose: 'xyz' });
+    p.end({ id: 'main', file: files.main, entry: true });
+
+    var rows = [];
+    p.on('data', function (row) { rows.push(row); });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: files.bar,
+                file: files.bar,
+                source: sources.bar,
+                deps: {xyz: files.xyz}
+            },
+            {
+                file: files.foo,
+                id: files.foo,
+                source: sources.foo,
+                deps: {'./lib/abc': files.abc}
+            },
+            {
+                id: 'abc',
+                file: files.abc,
+                source: sources.abc,
+                deps: {},
+                entry: true,
+                expose: 'abc'
+            },
+            {
+                id: 'main',
+                file: files.main,
+                source: sources.main,
+                deps: {
+                    './bar': files.bar,
+                    abc: files.abc,
+                    xyz: files.xyz
+                },
+                entry: true
+            },
+            {
+                id: 'xyz',
+                file: files.xyz,
+                source: sources.xyz,
+                deps: {'../foo': files.foo},
+                entry: true,
+                expose: 'xyz'
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/expose/bar.js
+++ b/test/expose/bar.js
@@ -1,0 +1,1 @@
+require('xyz');

--- a/test/expose/foo.js
+++ b/test/expose/foo.js
@@ -1,0 +1,1 @@
+require('./lib/abc');

--- a/test/expose/lib/abc.js
+++ b/test/expose/lib/abc.js
@@ -1,0 +1,1 @@
+console.log('abc');

--- a/test/expose/lib/xyz.js
+++ b/test/expose/lib/xyz.js
@@ -1,0 +1,2 @@
+require('../foo');
+console.log('xyz');

--- a/test/expose/main.js
+++ b/test/expose/main.js
@@ -1,0 +1,3 @@
+require('abc');
+require('xyz');
+require('./bar');


### PR DESCRIPTION
This fixes a nasty race condition that would result in disappearing `expose` and `entry` on rows (see https://github.com/substack/watchify/issues/177).

This happens when an input row (A) depends on another module that is also input row (B), and A finishes the **dep parsing** before B has **resolved**. This dependence is very typical with React. One module finishing parsing before another has even resolved happens pretty much always with watchify caching.

The solution proposed is to simply wait until the input rows have been resolved before continuing with their deps.

Out of the 4 tests added, only "test/cache_partial_expose.js" illustrates this bug. The rest are there because caching had no tests. I also tested Browserify with this fix and it all checks out.

cc: @jmm @substack 