### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "detective": "^4.0.0",
     "duplexer2": "0.0.2",
     "inherits": "^2.0.1",
-    "minimist": "~0.2.0",
     "parents": "^1.0.0",
     "readable-stream": "^1.0.27-1",
     "resolve": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "module-deps": "bin/cmd.js"
   },
   "dependencies": {
-    "JSONStream": "~0.7.1",
+    "JSONStream": "~0.10.0",
     "browser-resolve": "^1.7.0",
     "concat-stream": "~1.4.5",
-    "defined": "0.0.0",
+    "defined": "^1.0.0",
     "detective": "^4.0.0",
     "duplexer2": "0.0.2",
     "inherits": "^2.0.1",
@@ -20,7 +20,7 @@
     "resolve": "^1.1.3",
     "shallow-copy": "0.0.1",
     "stream-combiner2": "~1.0.0",
-    "subarg": "0.0.1",
+    "subarg": "^1.0.0",
     "through2": "~0.4.1",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
This part of https://github.com/substack/node-browserify/issues/707#issuecomment-96273418. Unfortunately we can't update to JSONStream@^1.0.1 (see https://github.com/dominictarr/JSONStream/pull/67), so ~0.10.0 will have to do.