### PR TITLE
Ensure "resolve" gets its own copy of "parent"

### DIFF
--- a/index.js
+++ b/index.js
@@ -332,7 +332,7 @@ Deps.prototype.walk = function (id, parent, cb) {
             var ts = self.getTransforms(file, pkg);
             ts.pipe(concat(function (body) {
                 rec.source = body.toString('utf8');
-                fromSource(rec.source);
+                fromSource(file, rec.source, pkg);
             }));
             return ts.end(rec.source);
         }
@@ -354,7 +354,7 @@ Deps.prototype.walk = function (id, parent, cb) {
             var ts = self.getTransforms(file, pkg);
             ts.pipe(concat(function (body) {
                 rec.source = body.toString('utf8');
-                fromSource(rec.source);
+                fromSource(file, rec.source, pkg);
             }));
             return ts.end(rec.source);
         }
@@ -367,15 +367,15 @@ Deps.prototype.walk = function (id, parent, cb) {
                 builtin: has(parent.modules, id)
             }))
             .pipe(concat(function (body) {
-                fromSource(body.toString('utf8'));
+                fromSource(file, body.toString('utf8'), pkg);
             }))
         ;
-        
-        function fromSource (src) {
-            var deps = rec.noparse ? [] : self.parseDeps(file, src);
-            if (deps) fromDeps(file, src, pkg, deps);
-        }
     });
+
+    function fromSource (file, src, pkg) {
+        var deps = rec.noparse ? [] : self.parseDeps(file, src);
+        if (deps) fromDeps(file, src, pkg, deps);
+    }
     
     function fromDeps (file, src, pkg, deps) {
         var p = deps.length;

--- a/index.js
+++ b/index.js
@@ -379,12 +379,6 @@ Deps.prototype.walk = function (id, parent, cb) {
     
     function fromDeps (file, src, pkg, deps) {
         var p = deps.length;
-        var current = {
-            id: file,
-            filename: file,
-            paths: self.paths,
-            package: pkg
-        };
         var resolved = {};
         
         if (input) --self.inputPending;
@@ -397,6 +391,12 @@ Deps.prototype.walk = function (id, parent, cb) {
                     if (--p === 0) done();
                     return;
                 }
+                var current = {
+                    id: file,
+                    filename: file,
+                    paths: self.paths,
+                    package: pkg
+                };
                 self.walk(id, current, function (err, r) {
                     resolved[id] = r;
                     if (--p === 0) done();


### PR DESCRIPTION
Hey @jmm and @terinjokes, mind giving this quick look?

_Readability improvement_ is pretty straight forward.

_Ensure "resolve" gets its own copy of "parent"_ is the alternative I discussed in https://github.com/substack/module-deps/pull/81#issuecomment-98904207. This change doesn't have any real effect, since that PR fixed the bug, but it goes a long way in helping to you understand what's going on when you're debugging.

> The _reason_ that module-deps is susceptible to this bug is because `parent` in `Deps.prototype.resolve = function (id, parent, cb) {}` is the exact same object for every dep in a file. `parent` is named `current` at its origin, and it comes from [here](https://github.com/substack/module-deps/blob/8e34e42/index.js#L382-L387). Notice how it's the same object [passed](https://github.com/substack/module-deps/blob/8e34e42/index.js#L400) into `walk`, which then passes it to `resolve` for every dep. The bug is that a new `parent.packageFilter` function is [tacked](https://github.com/substack/module-deps/blob/8e34e42/index.js#L150) on to the shared `parent` object. [...]

> Here is an alternate fix. It simply makes sure that every `resolve` gets its own `parent` object. So `parent.packageFilter` doesn't get clobbered, and `pkgdir` is properly preserved in its environment.