### PR TITLE
resolve deps to row.id rather than row.file

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function Deps (opts) {
     this._emittedPkg = {};
     this.visited = {};
     this.walking = {};
-    this.entries = [];
+    this.entries = {};
     this._input = [];
     
     this.paths = opts.paths || process.env.NODE_PATH || '';
@@ -87,7 +87,7 @@ Deps.prototype._transform = function (row, enc, next) {
     var basedir = defined(row.basedir, self.basedir);
     
     if (row.entry !== false) {
-        self.entries.push(path.resolve(basedir, row.file || row.id));
+        self.entries[path.resolve(basedir, row.file || row.id)] = row.id;
     }
     
     self.lookupPackage(row.file, function (err, pkg) {
@@ -199,7 +199,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     
     var isTopLevel;
     if (opts.builtin) isTopLevel = false;
-    else isTopLevel = this.entries.some(function (main) {
+    else isTopLevel = Object.keys(this.entries).some(function (main) {
         var m = path.relative(path.dirname(main), file);
         return m.split(/[\\\/]/).indexOf('node_modules') < 0;
     });
@@ -398,7 +398,11 @@ Deps.prototype.walk = function (id, parent, cb) {
                     package: pkg
                 };
                 self.walk(id, current, function (err, r) {
-                    resolved[id] = r;
+                    if (typeof self.entries[r] !== 'undefined') {
+                        resolved[id] = self.entries[r];
+                    } else {
+                        resolved[id] = r;
+                    }
                     if (--p === 0) done();
                 });
             });
@@ -411,7 +415,7 @@ Deps.prototype.walk = function (id, parent, cb) {
             if (!rec.deps) rec.deps = resolved;
             if (!rec.file) rec.file = file;
             
-            if (self.entries.indexOf(file) >= 0) {
+            if (self.entries.hasOwnProperty(file)) {
                 rec.entry = true;
             }
             self.push(rec);

--- a/test/cache_partial_expose.js
+++ b/test/cache_partial_expose.js
@@ -62,13 +62,13 @@ test('preserves expose and entry with partial cache', function(t) {
                 id: files.bar,
                 file: files.bar,
                 source: sources.bar,
-                deps: {xyz: files.xyz}
+                deps: {xyz: 'xyz'}
             },
             {
                 file: files.foo,
                 id: files.foo,
                 source: sources.foo,
-                deps: {'./lib/abc': files.abc}
+                deps: {'./lib/abc': 'abc'}
             },
             {
                 id: 'abc',
@@ -84,8 +84,8 @@ test('preserves expose and entry with partial cache', function(t) {
                 source: sources.main,
                 deps: {
                     './bar': files.bar,
-                    abc: files.abc,
-                    xyz: files.xyz
+                    abc: 'abc',
+                    xyz: 'xyz'
                 },
                 entry: true
             },

--- a/test/resolve_deps_to_id.js
+++ b/test/resolve_deps_to_id.js
@@ -1,0 +1,53 @@
+var parser = require('../');
+var test = require('tape');
+var fs = require('fs');
+var path = require('path');
+
+var files = {
+    main: path.join(__dirname, '/files/main.js'),
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = Object.keys(files).reduce(function (acc, file) {
+    acc[file] = fs.readFileSync(files[file], 'utf8');
+    return acc;
+}, {});
+
+test('deps resolve to id', function (t) {
+    t.plan(1);
+    var p = parser();
+    var fooID = path.relative(process.cwd(), files.foo);
+    p.write({ file: files.main, entry: true });
+    p.end({ file: files.foo, id: fooID, entry: true });
+    
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: files.main,
+                file: files.main,
+                source: sources.main,
+                entry: true,
+                deps: { './foo': fooID }
+            },
+            {
+                id: fooID,
+                file: files.foo,
+                source: sources.foo,
+                entry: true,
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                file: files.bar,
+                source: sources.bar,
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }
+


### PR DESCRIPTION
I encountered the problem in https://github.com/substack/node-browserify/issues/1260

I think there is something can be done in `module-deps` to fix that problem. But I am not sure if it's the right way.

The `rows` generated by `module-deps` should contain a dependency graph with the key `id` (identifying a node in the graph), yet  `row.deps` are resolved to absolute file paths, rather than the `id`s of the corresponding dependent rows, which means we may not find some dependent row from the `deps` property.

`The rows generated by module-deps should contain a dependency graph with the key `id` (identifying a node in the graph)`. I am sorry to bother, if I misunderstand the deps output.

Here is an example (with some twists to https://github.com/substack/module-deps/blob/master/example/deps.js):

```javascript
var mdeps = require('../');
var JSONStream = require('JSONStream');

var md = mdeps();
md.pipe(JSONStream.stringify()).pipe(process.stdout);
md.write({ file: './files/main.js' });
md.write({ file: './files/foo.js', id: './files/foo.js' }); // foo.js is required in main.js
md.end();
```

The output is:

```
[
{"file":"./files/main.js","id":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/main.js","source":"var foo = require('./foo');\nconsole.log('main: ' + foo(5));\n","deps":{"./foo":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/foo.js"},"entry":true}
,
{"id":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/bar.js","source":"module.exports = function (n) {\n    return n * 100;\n};\n","deps":{},"file":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/bar.js"}
,
{"file":"./files/foo.js","id":"./files/foo.js","source":"var bar = require('./bar');\n\nmodule.exports = function (n) {\n    return n * 111 + bar(n);\n};\n","deps":{"./bar":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/bar.js"},"entry":true}
]
```

The deps of `main.js` is `{"./foo":"/Users/zoubin/usr/src/zoubin/module-deps/example/files/foo.js"}`. It is impossible to retrieve the `foo.js` row from the output rows. And that is why I got an `undefined` deps in https://github.com/substack/node-browserify/issues/1260


