### PR TITLE
Use xtend instead of shallow-copy

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,6 @@ var concat = require('concat-stream');
 var parents = require('parents');
 var combine = require('stream-combiner2');
 var duplexer = require('duplexer2');
-var copy = require('shallow-copy');
 var xtend = require('xtend');
 var defined = require('defined');
 
@@ -51,7 +50,7 @@ function Deps (opts) {
     this.transforms = [].concat(opts.transform).filter(Boolean);
     this.globalTransforms = [].concat(opts.globalTransform).filter(Boolean);
     this.resolver = opts.resolve || browserResolve;
-    this.options = copy(opts || {});
+    this.options = xtend(opts);
     if (!this.options.modules) this.options.modules = {};
 
     // If the caller passes options.expose, store resolved pathnames for exposed
@@ -301,7 +300,7 @@ Deps.prototype.walk = function (id, parent, cb) {
     var rec = {};
     var input;
     if (typeof id === 'object') {
-        rec = copy(id);
+        rec = xtend(id);
         if (rec.entry === false) delete rec.entry;
         id = rec.file || rec.id;
         input = true;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "parents": "^1.0.0",
     "readable-stream": "^1.0.27-1",
     "resolve": "^1.1.3",
-    "shallow-copy": "0.0.1",
     "stream-combiner2": "~1.0.0",
     "subarg": "^1.0.0",
     "through2": "~0.4.1",

--- a/test/cache_partial_expose.js
+++ b/test/cache_partial_expose.js
@@ -2,7 +2,7 @@ var parser = require('../');
 var test = require('tape');
 var fs = require('fs');
 var path = require('path');
-var copy = require('shallow-copy');
+var xtend = require('xtend');
 
 var files = {
     abc: path.join(__dirname, '/expose/lib/abc.js'),
@@ -46,7 +46,7 @@ cache[files.main] = {
 test('preserves expose and entry with partial cache', function(t) {
     t.plan(1);
 
-    var partialCache = copy(cache);
+    var partialCache = xtend(cache);
     delete partialCache[files.bar];
 
     var p = parser({ cache: partialCache });


### PR DESCRIPTION
Just a bit of housekeeping. xtend already does what we're using shallow-copy for.