### PR TITLE
Alternative Paths when loading Transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     }
     
     function loadTransform (id, trOpts, cb) {
-        var params = { basedir: path.dirname(file) };
+        var params = { basedir: path.dirname(file), paths: self.paths };
         nodeResolve(id, params, function nr (err, res, again) {
             if (err && again) return cb && cb(err);
             

--- a/index.js
+++ b/index.js
@@ -272,7 +272,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             }
             
             if (!res) return cb(new Error(
-                'cannot find transform module ' + tr
+                'cannot find transform module ' + id
                 + ' while transforming ' + file
             ));
             


### PR DESCRIPTION
Pass the collection of `paths` through to `resolve` to support environments with 'interesting' node module environments ala https://github.com/tkellen/js-liftoff/pull/44/files

Patched up a minor bug in an error message whilst I was here as well.