### PR TITLE
file cache (useful for build system interoperability).

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function Deps (opts) {
     
     this.basedir = opts.basedir || process.cwd();
     this.cache = opts.cache;
+    this.fileCache = opts.fileCache;
     this.pkgCache = opts.packageCache || {};
     this.pkgFileCache = {};
     this.pkgFileCachePending = {};
@@ -181,8 +182,10 @@ Deps.prototype.resolve = function (id, parent, cb) {
 Deps.prototype.readFile = function (file, id, pkg) {
     var self = this;
     var tr = through();
-    if (this.cache && this.cache[file]) {
-        tr.push(this.cache[file].source);
+
+    var inputSource = this.fileCache && this.fileCache[file];
+    if (inputSource) {
+        tr.push(inputSource);
         tr.push(null);
         return tr;
     }

--- a/index.js
+++ b/index.js
@@ -156,8 +156,19 @@ Deps.prototype.resolve = function (id, parent, cb) {
     
     if (opts.extensions) parent.extensions = opts.extensions;
     if (opts.modules) parent.modules = opts.modules;
+
+    var resolver = function(id, parent, callback) {
+        var file = path.resolve(path.dirname(parent.id), id);
+        if (! /\.js$/.test(file))
+            file += '.js';
+
+        if (self.fileCache && self.fileCache[file])
+            callback(null, file);
+        else
+            self.resolver(id, parent, callback);
+    };
     
-    self.resolver(id, parent, function onresolve (err, file, pkg) {
+    resolver(id, parent, function onresolve (err, file, pkg) {
         if (err) return cb(err);
         if (!file) return cb(new Error(
             'module not found: "' + id + '" from file '

--- a/readme.markdown
+++ b/readme.markdown
@@ -91,6 +91,9 @@ this for large dependencies like jquery or threejs which take forever to parse.
 * `opts.packageCache` - an object mapping filenames to their parent package.json
 contents for browser fields, main entries, and transforms
 
+* `opts.fileCache` - an object mapping filenames to raw source to avoid reading
+from disk.
+
 * `opts.paths` - array of global paths to search. Defaults to splitting on `':'`
 in `process.env.NODE_PATH`
 

--- a/test/file_cache.js
+++ b/test/file_cache.js
@@ -1,0 +1,58 @@
+var mdeps = require('../');
+var test = require('tap').test;
+var path = require('path');
+var through = require('through2');
+
+var files = {
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+var sources = {
+    foo: 'require("./bar"); var tongs;',
+    bar: 'notreal tongs'
+};
+
+var fileCache = {};
+fileCache[files.foo] = sources.foo;
+fileCache[files.bar] = sources.bar;
+
+var specialReplace = function(input) {
+    return input.replace(/tongs/g, 'tangs');
+};
+
+test('uses file cache', function (t) {
+    t.plan(1);
+    var p = mdeps({
+        fileCache: fileCache,
+        transform: function (file) {
+            return through(function (buf, enc, next) {
+                this.push(specialReplace(String(buf)));
+                next();
+            });
+        },
+        transformKey: [ 'browserify', 'transform' ]
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: 'foo',
+                file: files.foo,
+                source: specialReplace(sources.foo),
+                deps: { './bar': files.bar }
+            },
+            {
+                id: files.bar,
+                file: files.bar,
+                source: specialReplace(sources.bar),
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }

--- a/test/file_cache.js
+++ b/test/file_cache.js
@@ -4,18 +4,18 @@ var path = require('path');
 var through = require('through2');
 
 var files = {
-    foo: path.join(__dirname, '/files/foo.js'),
-    bar: path.join(__dirname, '/files/bar.js')
+    fop: path.join(__dirname, '/files/fop.js'),
+    bat: path.join(__dirname, '/files/bat.js')
 };
 
 var sources = {
-    foo: 'require("./bar"); var tongs;',
-    bar: 'notreal tongs'
+    fop: 'require("./bat"); var tongs;',
+    bat: 'notreal tongs'
 };
 
 var fileCache = {};
-fileCache[files.foo] = sources.foo;
-fileCache[files.bar] = sources.bar;
+fileCache[files.fop] = sources.fop;
+fileCache[files.bat] = sources.bat;
 
 var specialReplace = function(input) {
     return input.replace(/tongs/g, 'tangs');
@@ -33,22 +33,22 @@ test('uses file cache', function (t) {
         },
         transformKey: [ 'browserify', 'transform' ]
     });
-    p.end({ id: 'foo', file: files.foo, entry: false });
+    p.end({ id: 'fop', file: files.fop, entry: false });
 
     var rows = [];
     p.on('data', function (row) { rows.push(row) });
     p.on('end', function () {
         t.same(rows.sort(cmp), [
             {
-                id: 'foo',
-                file: files.foo,
-                source: specialReplace(sources.foo),
-                deps: { './bar': files.bar }
+                id: 'fop',
+                file: files.fop,
+                source: specialReplace(sources.fop),
+                deps: { './bat': files.bat }
             },
             {
-                id: files.bar,
-                file: files.bar,
-                source: specialReplace(sources.bar),
+                id: files.bat,
+                file: files.bat,
+                source: specialReplace(sources.bat),
                 deps: {}
             }
         ].sort(cmp));


### PR DESCRIPTION
With this change I can add a cache entry for source file content without being forced to cache the deps.

If my build system already has all of the file data in memory (indeed using a streaming build system the data may not even exist on the filesystem) then it would be nice if module-deps could be told about this data so it doesn't have to read it from the filesystem.

You can do this by adding a `cache` entry, however cache entries must also contain the `deps`, the build system only has the source content not the deps. With this 10 character change the best of both worlds can be had.