### PR TITLE
do not apply root transforms on linked modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -157,7 +157,7 @@ Deps.prototype.resolve = function (id, parent, cb) {
     if (opts.extensions) parent.extensions = opts.extensions;
     if (opts.modules) parent.modules = opts.modules;
     
-    self.resolver(id, parent, function onresolve (err, file, pkg) {
+    self.resolver(id, parent, function onresolve (err, file, pkg, fakePath) {
         if (err) return cb(err);
         if (!file) return cb(new Error(
             'module not found: "' + id + '" from file '
@@ -171,11 +171,12 @@ Deps.prototype.resolve = function (id, parent, cb) {
                 if (!p.__dirname) p.__dirname = path.dirname(file);
                 self.pkgCache[file] = p;
                 onresolve(err, file, opts.packageFilter
-                    ? opts.packageFilter(p, p.__dirname) : p
+                    ? opts.packageFilter(p, p.__dirname) : p,
+                    fakePath
                 );
             });
         }
-        else cb(err, file, pkg);
+        else cb(err, file, pkg, fakePath);
     });
 };
 
@@ -194,6 +195,7 @@ Deps.prototype.readFile = function (file, id, pkg) {
 };
 
 Deps.prototype.getTransforms = function (file, pkg, opts) {
+    // TODO: Needs FAKE path here.
     if (!opts) opts = {};
     var self = this;
     
@@ -308,7 +310,7 @@ Deps.prototype.walk = function (id, parent, cb) {
         this.inputPending ++;
     }
     
-    self.resolve(id, parent, function (err, file, pkg) {
+    self.resolve(id, parent, function (err, file, pkg, fakePath) {
         if (rec.expose) {
             // Set options.expose to make the resolved pathname available to the
             // caller. They may or may not have requested it, but it's harmless
@@ -363,7 +365,7 @@ Deps.prototype.walk = function (id, parent, cb) {
         if (c) return fromDeps(file, c.source, c.package, Object.keys(c.deps));
         
         self.readFile(file, id, pkg)
-            .pipe(self.getTransforms(file, pkg, {
+            .pipe(self.getTransforms(fakePath || file, pkg, {
                 builtin: has(parent.modules, id)
             }))
             .pipe(concat(function (body) {


### PR DESCRIPTION
resolver now accepts a 4th argument which should be the original
(non-real) file path.

Required for fixing https://github.com/substack/node-browserify/issues/1386 / https://github.com/substack/node-browserify/pull/1365

Definitely could use a better variable name, so this is open for suggestion and comments.

This change is missing tests right now. I'll add them if I get some feedback that we might want to merge this.