### PR TITLE
Transforms should be applied if row.file and row.expose are equal

### DIFF
--- a/index.js
+++ b/index.js
@@ -311,6 +311,10 @@ Deps.prototype.walk = function (id, parent, cb) {
     }
     
     self.resolve(id, parent, function (err, file, pkg, fakePath) {
+        // this is checked early because parent.modules is also modified
+        // by this function.
+        var builtin = has(parent.modules, id);
+
         if (rec.expose) {
             // Set options.expose to make the resolved pathname available to the
             // caller. They may or may not have requested it, but it's harmless
@@ -366,7 +370,7 @@ Deps.prototype.walk = function (id, parent, cb) {
         
         self.readFile(file, id, pkg)
             .pipe(self.getTransforms(fakePath || file, pkg, {
-                builtin: has(parent.modules, id)
+                builtin: builtin
             }))
             .pipe(concat(function (body) {
                 fromSource(file, body.toString('utf8'), pkg);

--- a/test/pkg.js
+++ b/test/pkg.js
@@ -11,7 +11,7 @@ test('pkg', function (t) {
     var d = mdeps();
     d.on('package', function (pkg_) {
         var pkg = JSON.parse(fs.readFileSync(dirname + pkg_.dir + '/package.json'));
-        pkg.__dirname = dirname + pkg_.dir;
+        pkg.__dirname = path.join(dirname, pkg_.dir);
 
         t.deepEqual(pkg_, pkg);
     });

--- a/test/row_expose_name_is_file_transform.js
+++ b/test/row_expose_name_is_file_transform.js
@@ -1,0 +1,32 @@
+var parser = require('../');
+var test = require('tap').test;
+var through = require('through2');
+var path = require('path');
+
+// test that (non global) transforms are applied to an exposed module, where in the
+// exposed name is identical to the file path.
+test('row is exposed with a name equal to the path, and transformed', function (t) {
+        t.plan(2);
+        var exposed_path = path.join(__dirname, '/files/main.js');
+        var found_exposed_path = false;
+        var opts = {
+                expose: {},
+                transform: function(file) {
+                        if (file === exposed_path) {
+                                found_exposed_path = true;
+                        }
+                        return through();
+                }
+        };
+
+        var p = parser(opts);
+        p.end({ file: exposed_path, expose: exposed_path });
+        p.on('error', t.fail.bind(t));
+
+        p.pipe(through.obj());
+
+        p.on('end', function () {
+                t.equal(opts.expose[exposed_path], exposed_path);
+                t.ok(found_exposed_path);
+        });
+});

--- a/test/row_expose_transform.js
+++ b/test/row_expose_transform.js
@@ -1,0 +1,31 @@
+var parser = require('../');
+var test = require('tap').test;
+var through = require('through2');
+var path = require('path');
+
+// test that (non global) transforms are applied to an exposed module
+test('row is exposed and transformed', function (t) {
+    t.plan(2);
+    var exposed_path = path.join(__dirname, '/files/main.js');
+    var found_exposed_path = false;
+    var opts = { 
+        expose: {},
+        transform: function(file) {
+            if (file === exposed_path) {
+                found_exposed_path = true;
+            }
+            return through();
+        }
+    };
+
+    var p = parser(opts);
+    p.end({ file: exposed_path, expose: "whatever" });
+    p.on('error', t.fail.bind(t));
+
+    p.pipe(through.obj());
+
+    p.on('end', function () {
+        t.equal(opts.expose.whatever, exposed_path);
+        t.ok(found_exposed_path);
+    });
+});


### PR DESCRIPTION
The provided test case "row_expose_name_is_file_transform" fails without this fix.

This fixes #105 