### PR TITLE
pass options to transforms as `opts._flag`

### DIFF
--- a/index.js
+++ b/index.js
@@ -251,6 +251,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             trOpts = tr[1];
             tr = tr[0];
         }
+        trOpts._flags = trOpts.hasOwnProperty('_flags') ? trOpts._flags : self.options;
         if (typeof tr === 'function') {
             var t = tr(file, trOpts);
             self.emit('transform', t, file);

--- a/readme.markdown
+++ b/readme.markdown
@@ -150,7 +150,7 @@ to a module that is expected to follow this format:
 
 ``` js
 var through = require('through2');
-module.exports = function (file) { return through() };
+module.exports = function (file, opts) { return through() };
 ```
 
 You don't necessarily need to use the
@@ -205,6 +205,11 @@ and `ggg` gets `{"y":4}`:
   }
 }
 ```
+
+Options sent to the module-deps constructor are also provided under
+`opts._flags`. These options are sometimes required if your transform
+needs to do something different when browserify is run in debug mode, for
+example.
 
 # usage
 

--- a/test/tr_flags.js
+++ b/test/tr_flags.js
@@ -1,0 +1,44 @@
+var through = require('through2');
+var mdeps = require('../');
+var test = require('tap').test;
+
+test('--debug passed to transforms', function (t) {
+    var empty = require.resolve('./tr_flags/empty.js');
+
+    t.plan(5);
+
+    var p
+    [true, false].forEach(function(debug) {
+        p = mdeps({
+            debug: debug,
+            transform: function (file, opts) {
+              t.equal(opts._flags.debug, debug, 'debug: ' + debug);
+              return through();
+            }
+        })
+        p.on('error', function (err) { return t.fail(err.message) })
+        p.end(empty);
+
+        p = mdeps({ debug: debug })
+        p.write({
+            transform: function (file, opts) {
+                t.equal(opts._flags.debug, debug, 'debug: ' + debug);
+                return through();
+            },
+            options: {}
+        })
+        p.on('error', function (err) { return t.fail(err.message) })
+        p.end(empty);
+    });
+
+    p = mdeps({ debug: true })
+    p.write({
+        transform: function (file, opts) {
+            t.equal(opts._flags, Infinity, 'transform arguents are preserved');
+            return through();
+        },
+        options: { _flags: Infinity }
+    })
+    p.on('error', function (err) { return t.fail(err.message) })
+    p.end(empty);
+});

--- a/test/tr_flags.js
+++ b/test/tr_flags.js
@@ -34,7 +34,7 @@ test('--debug passed to transforms', function (t) {
     p = mdeps({ debug: true })
     p.write({
         transform: function (file, opts) {
-            t.equal(opts._flags, Infinity, 'transform arguents are preserved');
+            t.equal(opts._flags, Infinity, 'transform arguments are preserved');
             return through();
         },
         options: { _flags: Infinity }


### PR DESCRIPTION
fixes https://github.com/substack/node-browserify/issues/1463
supersedes https://github.com/substack/module-deps/pull/61