### PR TITLE
Make it so that passed-in 'paths' are respected when loading transforms

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,7 +270,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     }
     
     function loadTransform (id, trOpts, cb) {
-        var params = { basedir: path.dirname(file) };
+        var params = { basedir: path.dirname(file), paths: self.paths };
         nodeResolve(id, params, function nr (err, res, again) {
             if (err && again) return cb && cb(err);
             

--- a/test/files/findme/findme-transform.js
+++ b/test/files/findme/findme-transform.js
@@ -1,0 +1,8 @@
+var through = require('through2');
+
+module.exports = function (file) {
+    return through(function (buf, enc, next) {
+        this.push(String(buf).replace(/abcdef/g, '123456'));
+        next();
+    });
+};

--- a/test/files/findme/main.js
+++ b/test/files/findme/main.js
@@ -1,0 +1,2 @@
+module.exports = {};
+// abcdef

--- a/test/tr_paths.js
+++ b/test/tr_paths.js
@@ -1,0 +1,24 @@
+var mdeps = require('../');
+var test = require('tap').test;
+var JSONStream = require('JSONStream');
+var packer = require('browser-pack');
+var path = require('path');
+
+test('transform', function (t) {
+    t.plan(2);
+    var p = mdeps({
+        transform: [ 'findme-transform' ],
+        paths: [ path.join(__dirname, '/files/findme') ]
+    });
+    p.end(path.join(__dirname, '/files/findme/main.js'));
+    var pack = packer();
+
+    p.pipe(JSONStream.stringify()).pipe(pack);
+
+    var src = '';
+    pack.on('data', function (buf) { src += buf });
+    pack.on('end', function () {
+        t.ok(src.indexOf('abcdef') === -1, 'contains un-transformed output');
+        t.ok(src.indexOf('123456') > -1, 'missing transformed output');
+    });
+});


### PR DESCRIPTION
Doing:

```js
mdeps({ paths: ['/some/path'] })
```

...fails to resolve transforms under `/some/path`, and also ignores `$NODE_PATH`. This PR includes a unit test and a fix.