### PR TITLE
Readable streams can be passed to opts.fileCache

### DIFF
--- a/index.js
+++ b/index.js
@@ -196,8 +196,10 @@ Deps.prototype.resolve = function (id, parent, cb) {
 Deps.prototype.readFile = function (file, id, pkg) {
     var self = this;
     if (xhas(this.fileCache, file)) {
+        var c = this.fileCache[file];
+        if (typeof c.pipe === 'function') return c;
         var tr = through();
-        tr.push(this.fileCache[file]);
+        tr.push(c);
         tr.push(null);
         return tr;
     }

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "xtend": "^4.0.0"
   },
   "devDependencies": {
-    "tap": "^1.0.0",
-    "browser-pack": "^5.0.0"
+    "browser-pack": "^5.0.0",
+    "from2-string": "^1.1.0",
+    "tap": "^1.0.0"
   },
   "scripts": {
     "test": "tap test/*.js"

--- a/test/file_cache.js
+++ b/test/file_cache.js
@@ -2,20 +2,24 @@ var mdeps = require('../');
 var test = require('tap').test;
 var path = require('path');
 var through = require('through2');
+var fromString = require('from2-string');
 
 var files = {
     foo: path.join(__dirname, '/files/foo.js'),
-    bar: path.join(__dirname, '/files/bar.js')
+    bar: path.join(__dirname, '/files/bar.js'),
+    extra: path.join(__dirname, '/files/extra.js')
 };
 
 var sources = {
-    foo: 'require("./bar"); var tongs;',
-    bar: 'notreal tongs'
+    foo: 'require("./bar"); require("./extra"); var tongs;',
+    bar: 'notreal tongs',
+    extra: 'notreal tongs'
 };
 
 var fileCache = {};
 fileCache[files.foo] = sources.foo;
 fileCache[files.bar] = sources.bar;
+fileCache[files.extra] = fromString(sources.extra);
 
 var specialReplace = function(input) {
     return input.replace(/tongs/g, 'tangs');
@@ -43,12 +47,21 @@ test('uses file cache', function (t) {
                 id: 'foo',
                 file: files.foo,
                 source: specialReplace(sources.foo),
-                deps: { './bar': files.bar }
+                deps: {
+                    './bar': files.bar,
+                    './extra': files.extra
+                }
             },
             {
                 id: files.bar,
                 file: files.bar,
                 source: specialReplace(sources.bar),
+                deps: {}
+            },
+            {
+                id: files.extra,
+                file: files.extra,
+                source: specialReplace(sources.extra),
                 deps: {}
             }
         ].sort(cmp));


### PR DESCRIPTION
Allows stream.Readable instances in `fileCache`. Duck-typing the stream so other allowed types (String/Buffer) will not be affected.

Seemed like there is no provided way to persist the cache. I'm using a Proxy's `getOwnPropertyDescriptor` trap (triggered by `xhas`) to dynamically populate the cache with asynchronous `fs.readFile` calls.

Would otherwise suggest having an asynchronous `fileRead` API with a cache lookup callback in the options.