### PR TITLE
fix browserify cannot find module when use "npminstall" install packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -408,8 +408,8 @@ Deps.prototype.walk = function (id, parent, cb) {
                 }
                 var isTopLevel = self._isTopLevel(fakePath || file);
                 var current = {
-                    id: file,
-                    filename: file,
+                    id: fakePath || file,
+                    filename: fakePath || file,
                     paths: self.paths,
                     package: pkg,
                     inNodeModules: parent.inNodeModules || !isTopLevel


### PR DESCRIPTION
fix browserify cannot find "is-buffer" pacakge from "core-util-is" when use "npminstall" install packages.

You can use this repo ( [browserify-link-bug](https://github.com/allenm/browserify-link-bug) ) to reproduce this bug.