### PR TITLE
Support for an advanced “persistentCache”

### DIFF
--- a/index.js
+++ b/index.js
@@ -387,12 +387,7 @@ Deps.prototype.walk = function (id, parent, cb) {
         });
 
         function persistentCacheFallback (dataAsString, cb) {
-            var stream
-            if (dataAsString) {
-                stream = toStream(dataAsString)
-            } else {
-                stream = self.readFile(file, id, pkg)
-            }
+            var stream = dataAsString ? toStream(dataAsString) : self.readFile(file, id, pkg);
             stream
                 .pipe(self.getTransforms(fakePath || file, pkg, {
                     builtin: builtin,

--- a/index.js
+++ b/index.js
@@ -401,8 +401,8 @@ Deps.prototype.walk = function (id, parent, cb) {
                             source: src,
                             package: pkg,
                             deps: deps.reduce(function (deps, dep) {
-                                deps[dep] = true
-                                return deps
+                                deps[dep] = true;
+                                return deps;
                             }, {})
                         });
                     }

--- a/readme.markdown
+++ b/readme.markdown
@@ -97,7 +97,7 @@ from disk.
 * `opts.persistentCache` - a complex cache handler that allows async and persistent
     caching of data. A `persistentCache` needs to follow this interface:
     ```
-    function peristentCache (
+    function persistentCache (
         file, // the path to the file that is loaded
         id,   // the id that is used to reference this file
         pkg,  // the package that this file belongs to fallback

--- a/readme.markdown
+++ b/readme.markdown
@@ -94,6 +94,38 @@ contents for browser fields, main entries, and transforms
 * `opts.fileCache` - an object mapping filenames to raw source to avoid reading
 from disk.
 
+* `opts.persistentCache` - a complex cache handler that allows async and persistent
+    caching of data. A `persistentCache` needs to follow this interface:
+    ```
+    function peristentCache (
+        file, // the path to the file that is loaded
+        id,   // the id that is used to reference this file
+        pkg,  // the package that this file belongs to fallback
+        cb    // callback handler that receives the cache data
+    ) {
+        if (hasError()) {
+            return cb(error) // Pass any error to the callback
+        }
+        if (isInCache()) {
+            return cb(null, {
+                source: fs.readFileSync(file, 'utf8'), // String of the fully processed file
+                package: pkg, // The package for housekeeping
+                deps: {
+                    'id':  // id that is used to reference a required file
+                    'file' // file path to the required file
+                }
+            })
+        }
+        // optional (can be null) stream that provides the data from
+        // the hard disk, can be provided in case the file data is used
+        // to evaluate the cache identifier
+        stream = fs.createReadStream(file)
+
+        // fallback to the default reading
+        fallback(stream, cb)
+    }
+    ```
+
 * `opts.paths` - array of global paths to search. Defaults to splitting on `':'`
 in `process.env.NODE_PATH`
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -101,6 +101,7 @@ from disk.
         file, // the path to the file that is loaded
         id,   // the id that is used to reference this file
         pkg,  // the package that this file belongs to fallback
+        fallback, // async fallback handler to be called if the cache doesn't hold the given file 
         cb    // callback handler that receives the cache data
     ) {
         if (hasError()) {

--- a/test/cache_persistent.js
+++ b/test/cache_persistent.js
@@ -55,7 +55,7 @@ test('passes persistent cache error through', function (t) {
     p.on('error', function (err) { t.equals(err.message, 'foo') });
 });
 
-test('allow passing of a different stream', function (t) {
+test('allow passing of the raw source as string', function (t) {
     t.plan(1);
     var p = parser({
         persistentCache: function (file, id, pkg, fallback, cb) {

--- a/test/cache_persistent.js
+++ b/test/cache_persistent.js
@@ -59,7 +59,7 @@ test('allow passing of a different stream', function (t) {
     t.plan(1);
     var p = parser({
         persistentCache: function (file, id, pkg, fallback, cb) {
-            fallback(fs.createReadStream(files.bar), cb)
+            fallback(fs.readFileSync(files.bar, 'utf8'), cb)
         }
     });
     p.end({ id: 'foo', file: files.foo, entry: false });

--- a/test/cache_persistent.js
+++ b/test/cache_persistent.js
@@ -1,0 +1,81 @@
+var parser = require('../');
+var test = require('tap').test;
+var path = require('path');
+var fs = require('fs');
+
+var files = {
+    foo: path.join(__dirname, '/files/foo.js'),
+    bar: path.join(__dirname, '/files/bar.js')
+};
+
+test('uses persistent cache', function (t) {
+    t.plan(1);
+    var p = parser({
+        persistentCache: function (file, id, pkg, fallback, cb) {
+            if (file === files.bar) {
+                return fallback(null, cb)
+            }
+            cb(null, {
+                source: 'file at ' + file + '@' + id,
+                package: pkg,
+                deps: { './bar': files.bar }
+            })
+        }
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: files.bar,
+                file: files.bar,
+                source: fs.readFileSync(files.bar, 'utf8'),
+                deps: {}
+            },
+            {
+                id: 'foo',
+                file: files.foo,
+                source: 'file at ' + files.foo + '@' + files.foo,
+                deps: { './bar': files.bar }
+            }
+        ].sort(cmp));
+    });
+});
+
+test('passes persistent cache error through', function (t) {
+    t.plan(1);
+    var p = parser({
+        persistentCache: function (file, id, pkg, fallback, cb) {
+            cb(new Error('foo'))
+        }
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+    p.on('error', function (err) { t.equals(err.message, 'foo') });
+});
+
+test('allow passing of a different stream', function (t) {
+    t.plan(1);
+    var p = parser({
+        persistentCache: function (file, id, pkg, fallback, cb) {
+            fallback(fs.createReadStream(files.bar), cb)
+        }
+    });
+    p.end({ id: 'foo', file: files.foo, entry: false });
+
+    var rows = [];
+    p.on('data', function (row) { rows.push(row) });
+    p.on('end', function () {
+        t.same(rows.sort(cmp), [
+            {
+                id: 'foo',
+                file: files.foo,
+                source: fs.readFileSync(files.bar, 'utf8'),
+                deps: {}
+            }
+        ].sort(cmp));
+    });
+});
+
+function cmp (a, b) { return a.id < b.id ? -1 : 1 }


### PR DESCRIPTION
There are a few implementations of persistent caches for browserify such as [`persistify`](https://github.com/royriojas/persistify) or [`browserify-incremental`](https://github.com/jsdf/browserify-incremental). But looking at each implementation it seemed like  they struggle with the interface given by `module-deps` to cache: which is just an object lookup. This PR adds an additional cache interface to `module-deps` that should make it possible to implement not just resource-efficient but also less hacky caching solutions for browserify.