### PR TITLE
allow a dependent module to specify a default transform field

### DIFF
--- a/index.js
+++ b/index.js
@@ -222,7 +222,8 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
     var transforms = [].concat(isTopLevel ? this.transforms : [])
         .concat(getTransforms(pkg, {
             globalTransform: this.globalTransforms,
-            transformKey: this.options.transformKey
+            transformKey: this.options.transformKey,
+            defaultTransformKey: this.options.defaultTransformKey
         }))
     ;
     if (transforms.length === 0) return through();
@@ -547,19 +548,19 @@ Deps.prototype.lookupPackage = function (file, cb) {
 };
  
 function getTransforms (pkg, opts) {
-    var trx = [];
-    if (opts.transformKey) {
-        var n = pkg;
-        var keys = opts.transformKey;
-        for (var i = 0; i < keys.length; i++) {
-            if (n && typeof n === 'object') n = n[keys[i]];
-            else break;
-        }
-        if (i === keys.length) {
-            trx = [].concat(n).filter(Boolean);
-        }
-    }
+    var trx = getTrx(opts.transformKey, pkg);
+    if (!trx) trx = getTrx(opts.defaultTransformKey, pkg) || [];
     return trx.concat(opts.globalTransform || []);
+}
+
+function getTrx (keys, n) {
+  if (keys) {
+    for (var i = 0; i < keys.length; i++) {
+      if (n && typeof n === 'object') n = n[keys[i]];
+      else break;
+    }
+    if (i === keys.length && n) return [].concat(n).filter(Boolean);
+  }
 }
 
 function nextTick (cb) {

--- a/readme.markdown
+++ b/readme.markdown
@@ -68,6 +68,9 @@ Optionally pass in some `opts`:
 package.json for source transformations. If falsy, don't look at the
 package.json at all.
 
+* `opts.defaultTransformKey` - if provided, used as a fallback
+in case `opts.transformKey` was not provided or couldn't find any transforms
+
 * `opts.resolve` - custom resolve function using the
 `opts.resolve(id, parent, cb)` signature that
 [browser-resolve](https://github.com/shtylman/node-browser-resolve) has


### PR DESCRIPTION
as a fallback
example: https://github.com/substack/node-browserify/pull/1721