### PR TITLE
End output stream on transform error

### DIFF
--- a/index.js
+++ b/index.js
@@ -254,6 +254,7 @@ Deps.prototype.getTransforms = function (file, pkg, opts) {
             err.message += ' while parsing file: ' + file;
             if (!err.filename) err.filename = file;
             dup.emit('error', err);
+            output.end(err);
         });
         input.pipe(middle).pipe(output);
     }


### PR DESCRIPTION
Browserify currently has an edge-case with multiple entryfiles, where if only some of a `transform` operation's streams emit errors, the Browserify process never exits.

From my debugging this change seems to do the trick, properly closing the output stream on an emitted error.

Example of current error behavior: https://gist.github.com/f0x52/ca28d3cca527798c776e9741648666bf